### PR TITLE
add craftable icon option to me storage screen

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -452,6 +452,7 @@
   "gui.ae2.SearchSettingsClearExternal": "Clear %s search on open",
   "gui.ae2.SearchSettingsRememberSearch": "Remember last search",
   "gui.ae2.SearchSettingsReplaceWithExternal": "Replace with %s search",
+  "gui.ae2.SearchSettingsShowCraftableIcon": "Show craftable icon",
   "gui.ae2.SearchSettingsSyncWithExternal": "Sync with %s search",
   "gui.ae2.SearchSettingsTitle": "Search Settings",
   "gui.ae2.SearchSettingsUseExternalSearch": "Use %s",

--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.systems.RenderSystem;
 
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
@@ -73,6 +74,7 @@ import appeng.client.gui.widgets.ToolboxPanel;
 import appeng.client.gui.widgets.UpgradesPanel;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
+import appeng.core.definitions.AEItems;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.Tooltips;
@@ -588,6 +590,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
                         var craftLabelText = useLargeFonts ? GuiText.LargeFontCraft.getLocal()
                                 : GuiText.SmallFontCraft.getLocal();
                         StackSizeRenderer.renderSizeLabel(guiGraphics, this.font, s.x, s.y, craftLabelText);
+                        drawCraftable(guiGraphics, s.x, s.y);
                     } else {
                         AmountFormat format = useLargeFonts ? AmountFormat.SLOT_LARGE_FONT
                                 : AmountFormat.SLOT;
@@ -595,6 +598,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
                         StackSizeRenderer.renderSizeLabel(guiGraphics, this.font, s.x, s.y, text, useLargeFonts);
                         if (craftable) {
                             StackSizeRenderer.renderSizeLabel(guiGraphics, this.font, s.x - 11, s.y - 11, "+", false);
+                            drawCraftable(guiGraphics, s.x, s.y);
                         }
                     }
                 }
@@ -604,6 +608,23 @@ public class MEStorageScreen<C extends MEStorageMenu>
         }
 
         super.renderSlot(guiGraphics, s);
+    }
+
+    private void drawCraftable(GuiGraphics guiGraphics, int x, int y) {
+        if (!AEConfig.instance().isShowCraftableIcon())
+            return;
+        RenderSystem.disableBlend();
+        var pose = guiGraphics.pose();
+        pose.pushPose();
+        pose.scale(0.5f, 0.5f, 1.0f);
+        pose.translate(x, y, 200.0f);
+        AEKeyRendering.drawInGui(
+                minecraft,
+                guiGraphics,
+                x,
+                y,
+                AEItemKey.of(AEItems.CRAFTING_PATTERN));
+        pose.popPose();
     }
 
     /**

--- a/src/main/java/appeng/client/gui/me/common/TerminalSettingsScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/TerminalSettingsScreen.java
@@ -22,6 +22,7 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
     private final AECheckbox useInternalSearchRadio;
     private final AECheckbox useExternalSearchRadio;
 
+    private final AECheckbox showCraftableIconCheckBox;
     private final AECheckbox rememberCheckbox;
     private final AECheckbox autoFocusCheckbox;
     private final AECheckbox syncWithExternalCheckbox;
@@ -61,6 +62,9 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
         useExternalSearchRadio.setRadio(true);
         useExternalSearchRadio.active = hasExternalSearch;
 
+        showCraftableIconCheckBox = widgets.addCheckbox("showCraftableIconCheckBox",
+                GuiText.SearchSettingsShowCraftableIcon.text(),
+                this::save);
         rememberCheckbox = widgets.addCheckbox("rememberCheckbox", GuiText.SearchSettingsRememberSearch.text(),
                 this::save);
         autoFocusCheckbox = widgets.addCheckbox("autoFocusCheckbox", GuiText.SearchSettingsAutoFocus.text(),
@@ -110,11 +114,13 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
 
         useInternalSearchRadio.setSelected(!config.isUseExternalSearch());
         useExternalSearchRadio.setSelected(config.isUseExternalSearch());
+        showCraftableIconCheckBox.setSelected(config.isShowCraftableIcon());
         rememberCheckbox.setSelected(config.isRememberLastSearch());
         autoFocusCheckbox.setSelected(config.isAutoFocusSearch());
         syncWithExternalCheckbox.setSelected(config.isSyncWithExternalSearch());
         clearExternalCheckbox.setSelected(config.isClearExternalSearchOnOpen());
 
+        showCraftableIconCheckBox.visible = useInternalSearchRadio.isSelected();
         rememberCheckbox.visible = useInternalSearchRadio.isSelected();
         autoFocusCheckbox.visible = useInternalSearchRadio.isSelected();
         syncWithExternalCheckbox.visible = useInternalSearchRadio.isSelected();
@@ -123,6 +129,7 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
     }
 
     private void save() {
+        config.setShowCraftableIcon(showCraftableIconCheckBox.isSelected());
         config.setUseExternalSearch(useExternalSearchRadio.isSelected());
         config.setRememberLastSearch(rememberCheckbox.isSelected());
         config.setAutoFocusSearch(autoFocusCheckbox.isSelected());

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -259,6 +259,14 @@ public final class AEConfig {
         CLIENT.clearExternalSearchOnOpen.set(enable);
     }
 
+    public boolean isShowCraftableIcon() {
+        return CLIENT.showCraftableIcon.get();
+    }
+
+    public void setShowCraftableIcon(boolean enable) {
+        CLIENT.showCraftableIcon.set(enable);
+    }
+
     public boolean isRememberLastSearch() {
         return CLIENT.rememberLastSearch.get();
     }
@@ -569,6 +577,7 @@ public final class AEConfig {
         public final BooleanOption syncWithExternalSearch;
         public final BooleanOption rememberLastSearch;
         public final BooleanOption autoFocusSearch;
+        public final BooleanOption showCraftableIcon;
 
         // Tooltip settings
         public final BooleanOption tooltipShowCellUpgrades;
@@ -618,6 +627,8 @@ public final class AEConfig {
                     "Remembers the last search term and restores it when the terminal opens");
             this.autoFocusSearch = search.addBoolean("autoFocusSearch", false,
                     "Automatically focuses the search field when the terminal opens");
+            this.showCraftableIcon = search.addBoolean("showCraftableIcon", true,
+                    "Show an icon on craftable items in the network");
 
             var tooltips = root.subsection("tooltips");
             this.tooltipShowCellUpgrades = tooltips.addBoolean("showCellUpgrades", true,

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -225,6 +225,7 @@ public enum GuiText implements LocalizationEnum {
     SearchSettingsUseInternalSearch("Use AE"),
     SearchSettingsUseExternalSearch("Use %s"),
     SearchSettingsRememberSearch("Remember last search"),
+    SearchSettingsShowCraftableIcon("Show craftable icon"),
     SearchSettingsAutoFocus("Auto-Focus on open"),
     SearchSettingsSyncWithExternal("Sync with %s search"),
     SearchSettingsClearExternal("Clear %s search on open"),

--- a/src/main/resources/assets/ae2/screens/terminals/terminal_settings.json
+++ b/src/main/resources/assets/ae2/screens/terminals/terminal_settings.json
@@ -55,7 +55,7 @@
       "top": 124,
       "width": 75
     },
-    "searchTooltipsCheckbox": {
+    "showCraftableIconCheckBox": {
       "left": 10,
       "top": 144,
       "width": 150


### PR DESCRIPTION
Aims the replicate the feature from gtnh where craftables have a small pattern icon over them, this would optionally replace the `+` icon currently present