### PR TITLE
Fix renaming items in pattern encoding

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -636,7 +636,7 @@
   "gui.tooltips.ae2.MiddleClick": "Middle-Click",
   "gui.tooltips.ae2.Mod": "Mod",
   "gui.tooltips.ae2.ModifyAmountAction": "%s: Modify Amount",
-  "gui.tooltips.ae2.ModifyNameAction": "%s: Modify Name",
+  "gui.tooltips.ae2.ModifyNameAction": "%s: Modify Name (only available for items)",
   "gui.tooltips.ae2.MouseButton": "Mouse %d",
   "gui.tooltips.ae2.MoveWhenEmpty": "Move to output when empty.",
   "gui.tooltips.ae2.MoveWhenFull": "Move to output when full.",

--- a/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
@@ -33,6 +33,7 @@ import net.minecraft.world.item.ItemStack;
 import appeng.api.behaviors.ContainerItemStrategies;
 import appeng.api.behaviors.EmptyingAction;
 import appeng.api.config.ActionItems;
+import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.GenericStack;
 import appeng.client.gui.me.common.MEStorageScreen;
 import appeng.client.gui.me.common.StackSizeRenderer;
@@ -101,14 +102,16 @@ public class PatternEncodingTermScreen<C extends PatternEncodingTermMenu> extend
                 var currentStack = GenericStack.fromItemStack(slot.getItem());
                 if (currentStack != null) {
                     if (hasControlDown()) {
-                        // Set stack name
-                        var screen = new SetProcessingPatternNameScreen<>(
-                                this,
-                                currentStack,
-                                newStack -> NetworkHandler.instance().sendToServer(new InventoryActionPacket(
-                                        InventoryAction.SET_FILTER, slot.index,
-                                        GenericStack.wrapInItemStack(newStack))));
-                        switchToScreen(screen);
+                        if (currentStack.what().getType().equals(AEKeyType.items())) {
+                            // Set stack name
+                            var screen = new SetProcessingPatternNameScreen<>(
+                                    this,
+                                    currentStack,
+                                    newStack -> NetworkHandler.instance().sendToServer(new InventoryActionPacket(
+                                            InventoryAction.SET_FILTER, slot.index,
+                                            GenericStack.wrapInItemStack(newStack))));
+                            switchToScreen(screen);
+                        }
                     } else {
                         // Set stack amount
                         var screen = new SetProcessingPatternAmountScreen<>(

--- a/src/main/java/appeng/client/gui/me/items/SetProcessingPatternNameScreen.java
+++ b/src/main/java/appeng/client/gui/me/items/SetProcessingPatternNameScreen.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.network.chat.Component;
 
+import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.GenericStack;
 import appeng.client.gui.AESubScreen;
 import appeng.client.gui.widgets.TabButton;
@@ -48,9 +49,13 @@ public class SetProcessingPatternNameScreen<C extends PatternEncodingTermMenu>
 
     private void setName() {
         String newName = name.getValue();
-        var itemStack = currentStack.what().wrapForDisplayOrFilter();
+        long amount = currentStack.amount();
+        var itemStack = ((AEItemKey) currentStack.what()).toStack();
         itemStack.setHoverName(Component.literal(newName));
-        setter.accept(GenericStack.fromItemStack(itemStack));
+
+        AEItemKey newKey = AEItemKey.of(itemStack);
+
+        setter.accept(new GenericStack(newKey, amount));
         returnToParent();
     }
 }

--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -199,7 +199,7 @@ public enum ButtonToolTips implements LocalizationEnum {
     StoreAction("%s: Store %s"),
     SetAction("%s: Set %s"),
     ModifyAmountAction("%s: Modify Amount"),
-    ModifyNameAction("%s: Modify Name"),
+    ModifyNameAction("%s: Modify Name (only available for items)"),
     SupportedBy("Supported by:"),
     LinkWirelessTerminal("Link Wireless Terminals here"),
     PlaceWirelessBooster("Increase range with Wireless Boosters"),


### PR DESCRIPTION
Notably:
* Will preserve item amount
* Will not try to rename fluid stacks

~~typo in commit message :crying_cat_face:~~