### PR TITLE
Highlight stacks from terminal in-world

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -991,6 +991,7 @@
   "item.ae2.yellow_smart_dense_cable": "Yellow ME Dense Smart Cable",
   "key.ae2.category": "Applied Energistics 2",
   "key.ae2.guide": "Open Guide for Items",
+  "key.ae2.highlight_stacks": "Highlight Stored Locations",
   "key.ae2.portable_fluid_cell": "Open Portable Fluid Cell",
   "key.ae2.portable_item_cell": "Open Portable Item Cell",
   "key.ae2.wireless_terminal": "Open Wireless Terminal",

--- a/src/main/java/appeng/api/features/HotkeyAction.java
+++ b/src/main/java/appeng/api/features/HotkeyAction.java
@@ -21,6 +21,8 @@ public interface HotkeyAction {
     String PORTABLE_ITEM_CELL = "portable_item_cell";
     String PORTABLE_FLUID_CELL = "portable_fluid_cell";
 
+    String HIGHLIGHT_STACKS = "highlight_stacks";
+
     /**
      * register a new {@link HotkeyAction} under an id
      * <p/>

--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -48,6 +48,7 @@ import appeng.api.config.SortDir;
 import appeng.api.config.SortOrder;
 import appeng.api.config.TypeFilter;
 import appeng.api.config.ViewItems;
+import appeng.api.features.HotkeyAction;
 import appeng.api.ids.AETags;
 import appeng.api.implementations.blockentities.IMEChest;
 import appeng.api.stacks.AEItemKey;
@@ -78,6 +79,7 @@ import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.Tooltips;
 import appeng.core.sync.network.NetworkHandler;
+import appeng.core.sync.packets.BlockHighlightPacket;
 import appeng.core.sync.packets.ConfigValuePacket;
 import appeng.core.sync.packets.MEInteractionPacket;
 import appeng.core.sync.packets.SwitchGuisPacket;
@@ -712,6 +714,19 @@ public class MEStorageScreen<C extends MEStorageMenu>
         if (!this.searchField.isFocused() && isCloseHotkey(keyCode, scanCode)) {
             this.getPlayer().closeContainer();
             return true;
+        }
+
+        var hotKey = Hotkeys.getHotkeyMapping(HotkeyAction.HIGHLIGHT_STACKS);
+        if (hotKey != null && hotKey.mapping().matches(keyCode, scanCode)) {
+            if (this.hoveredSlot instanceof RepoSlot repoSlot) {
+                var entry = repoSlot.getEntry();
+                if (entry != null && entry.getStoredAmount() > 0) {
+                    hotKey.mapping().consumeClick();
+                    var packet = new BlockHighlightPacket.HighlightWhat(entry.getWhat());
+                    NetworkHandler.instance().sendToServer(packet);
+                    return true;
+                }
+            }
         }
 
         return super.keyPressed(keyCode, scanCode, p_keyPressed_3_);

--- a/src/main/java/appeng/core/sync/packets/BlockHighlightPacket.java
+++ b/src/main/java/appeng/core/sync/packets/BlockHighlightPacket.java
@@ -15,7 +15,7 @@ import appeng.api.stacks.AEKey;
 import appeng.client.render.BlockHighlightHandler;
 import appeng.core.localization.PlayerMessages;
 import appeng.core.sync.BasePacket;
-import appeng.menu.me.crafting.CraftingCPUMenu;
+import appeng.menu.interfaces.IHighlightableMenu;
 
 public class BlockHighlightPacket extends BasePacket {
     private final BlockPos pos;
@@ -68,8 +68,8 @@ public class BlockHighlightPacket extends BasePacket {
         @Override
         public void serverPacketData(ServerPlayer player) {
             var menu = player.containerMenu;
-            if (menu instanceof CraftingCPUMenu cpuMenu) {
-                cpuMenu.highlight(what);
+            if (menu instanceof IHighlightableMenu highlightableMenu) {
+                highlightableMenu.highlight(what);
             }
         }
     }

--- a/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
+++ b/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
@@ -124,6 +124,7 @@ public class LocalizationProvider implements IAE2DataProvider {
         add("key.ae2.portable_fluid_cell", "Open Portable Fluid Cell");
         add("key.ae2.portable_item_cell", "Open Portable Item Cell");
         add("key.ae2.wireless_terminal", "Open Wireless Terminal");
+        add("key.ae2.highlight_stacks", "Highlight Stored Locations");
         add("key.ae2.guide", "Open Guide for Items");
         add("key.toggle_focus.desc", "Toggle search box focus");
         add("stat.ae2.items_extracted", "Items extracted from ME Storage");

--- a/src/main/java/appeng/hotkeys/HighlightHotkeyAction.java
+++ b/src/main/java/appeng/hotkeys/HighlightHotkeyAction.java
@@ -1,0 +1,13 @@
+package appeng.hotkeys;
+
+import net.minecraft.world.entity.player.Player;
+
+import appeng.api.features.HotkeyAction;
+
+public class HighlightHotkeyAction implements HotkeyAction {
+    @Override
+    public boolean run(Player player) {
+        // NO-OP, everything is handled
+        return true;
+    }
+}

--- a/src/main/java/appeng/hotkeys/HotkeyActions.java
+++ b/src/main/java/appeng/hotkeys/HotkeyActions.java
@@ -1,5 +1,6 @@
 package appeng.hotkeys;
 
+import static appeng.api.features.HotkeyAction.HIGHLIGHT_STACKS;
 import static appeng.api.features.HotkeyAction.PORTABLE_FLUID_CELL;
 import static appeng.api.features.HotkeyAction.PORTABLE_ITEM_CELL;
 import static appeng.api.features.HotkeyAction.WIRELESS_TERMINAL;
@@ -42,6 +43,8 @@ public class HotkeyActions {
         registerPortableCell(AEItems.PORTABLE_FLUID_CELL16K, PORTABLE_FLUID_CELL);
         registerPortableCell(AEItems.PORTABLE_FLUID_CELL64K, PORTABLE_FLUID_CELL);
         registerPortableCell(AEItems.PORTABLE_FLUID_CELL256K, PORTABLE_FLUID_CELL);
+
+        register(new HighlightHotkeyAction(), HIGHLIGHT_STACKS);
     }
 
     /**

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -31,7 +31,9 @@ import com.google.common.collect.SetMultimap;
 
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
@@ -48,6 +50,7 @@ import appeng.api.storage.MEStorage;
 import appeng.me.helpers.InterestManager;
 import appeng.me.helpers.StackWatcher;
 import appeng.me.storage.NetworkStorage;
+import appeng.parts.AEBasePart;
 
 public class StorageService implements IStorageService, IGridServiceProvider {
 
@@ -287,5 +290,38 @@ public class StorageService implements IStorageService, IGridServiceProvider {
         private void unmount(MEStorage inventory) {
             storage.unmount(inventory);
         }
+    }
+
+    /**
+     * Returns the in-world block positions where the given key is stored (drives, storage buses). Used for highlighting
+     * storage locations in the terminal UI.
+     */
+    public Set<BlockPos> getStorageLocations(AEKey key) {
+        Set<BlockPos> locations = new HashSet<>();
+        var counter = new KeyCounter();
+        for (var entry : nodeProviders.entrySet()) {
+            var node = entry.getKey();
+            var state = entry.getValue();
+            var owner = node.getOwner();
+            BlockPos pos = null;
+            if (owner instanceof BlockEntity be) {
+                pos = be.getBlockPos();
+            }
+            if (owner instanceof AEBasePart part) {
+                pos = part.getBlockEntity().getBlockPos();
+            }
+            if (pos == null) {
+                continue;
+            }
+            for (var inv : state.inventories) {
+                counter.clear();
+                inv.getAvailableStacks(counter);
+                if (counter.get(key) > 0) {
+                    locations.add(pos);
+                    break;
+                }
+            }
+        }
+        return locations;
     }
 }

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -30,6 +30,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -53,6 +55,7 @@ import appeng.me.storage.NetworkStorage;
 import appeng.parts.AEBasePart;
 
 public class StorageService implements IStorageService, IGridServiceProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StorageService.class);
 
     /**
      * Tracks the storage service's state for each grid node that provides storage to the network.
@@ -306,9 +309,10 @@ public class StorageService implements IStorageService, IGridServiceProvider {
             BlockPos pos = null;
             if (owner instanceof BlockEntity be) {
                 pos = be.getBlockPos();
-            }
-            if (owner instanceof AEBasePart part) {
+            } else if (owner instanceof AEBasePart part) {
                 pos = part.getBlockEntity().getBlockPos();
+            } else {
+                LOGGER.warn("Could not get position for owner {} on node {}, please report this issue.", owner, node);
             }
             if (pos == null) {
                 continue;

--- a/src/main/java/appeng/menu/interfaces/IHighlightableMenu.java
+++ b/src/main/java/appeng/menu/interfaces/IHighlightableMenu.java
@@ -1,0 +1,10 @@
+package appeng.menu.interfaces;
+
+import appeng.api.stacks.AEKey;
+
+/**
+ * Implement this interface on any menu that can highlight something in-world.
+ */
+public interface IHighlightableMenu {
+    void highlight(AEKey what);
+}

--- a/src/main/java/appeng/menu/me/common/MEStorageMenu.java
+++ b/src/main/java/appeng/menu/me/common/MEStorageMenu.java
@@ -69,19 +69,23 @@ import appeng.api.storage.cells.IBasicCellItem;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.client.gui.me.common.MEStorageScreen;
+import appeng.client.render.BlockHighlightHandler;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
+import appeng.core.sync.packets.BlockHighlightPacket;
 import appeng.core.sync.packets.ConfigValuePacket;
 import appeng.core.sync.packets.MEInteractionPacket;
 import appeng.core.sync.packets.MEInventoryUpdatePacket;
 import appeng.helpers.InventoryAction;
 import appeng.me.helpers.ChannelPowerSrc;
+import appeng.me.service.StorageService;
 import appeng.menu.AEBaseMenu;
 import appeng.menu.PatternBoxMenu;
 import appeng.menu.SlotSemantics;
 import appeng.menu.ToolboxMenu;
 import appeng.menu.guisync.GuiSync;
 import appeng.menu.implementations.MenuTypeBuilder;
+import appeng.menu.interfaces.IHighlightableMenu;
 import appeng.menu.me.crafting.CraftAmountMenu;
 import appeng.menu.slot.AppEngSlot;
 import appeng.menu.slot.RestrictedInputSlot;
@@ -93,7 +97,7 @@ import appeng.util.Platform;
  * @see MEStorageScreen
  */
 public class MEStorageMenu extends AEBaseMenu
-        implements IConfigManagerListener, IConfigurableObject, IMEInteractionHandler {
+        implements IConfigManagerListener, IConfigurableObject, IMEInteractionHandler, IHighlightableMenu {
 
     public static final MenuType<MEStorageMenu> TYPE = MenuTypeBuilder
             .<MEStorageMenu, ITerminalHost>create(MEStorageMenu::new, ITerminalHost.class)
@@ -759,5 +763,34 @@ public class MEStorageMenu extends AEBaseMenu
 
     public ITerminalHost getHost() {
         return host;
+    }
+
+    @Override
+    public void highlight(AEKey what) {
+        if (!canInteractWithGrid()) {
+            return;
+        }
+        if (what == null) {
+            return;
+        }
+        if (networkNode == null) {
+            return;
+        }
+        var grid = networkNode.getGrid();
+        if (grid == null) {
+            return;
+        }
+        var storageService = grid.getStorageService();
+        if (!(storageService instanceof StorageService service)) {
+            return;
+        }
+        var positions = service.getStorageLocations(what);
+        var level = networkNode.getLevel();
+        var dim = level.dimension();
+        for (var pos : positions) {
+            var packet = new BlockHighlightPacket(pos, dim,
+                    BlockHighlightHandler.getTime(pos, this.getPlayer().getOnPos()));
+            sendPacketToClient(packet);
+        }
     }
 }

--- a/src/main/java/appeng/menu/me/crafting/CraftingCPUMenu.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingCPUMenu.java
@@ -46,12 +46,13 @@ import appeng.me.service.CraftingService;
 import appeng.menu.AEBaseMenu;
 import appeng.menu.guisync.GuiSync;
 import appeng.menu.implementations.MenuTypeBuilder;
+import appeng.menu.interfaces.IHighlightableMenu;
 import appeng.menu.me.common.IncrementalUpdateHelper;
 
 /**
  * @see appeng.client.gui.me.crafting.CraftingCPUScreen
  */
-public class CraftingCPUMenu extends AEBaseMenu {
+public class CraftingCPUMenu extends AEBaseMenu implements IHighlightableMenu {
 
     private static final String ACTION_CANCEL_CRAFTING = "cancelCrafting";
     private static final String ACTION_TOGGLE_SCHEDULING = "toggleScheduling";
@@ -192,6 +193,7 @@ public class CraftingCPUMenu extends AEBaseMenu {
         return this.grid;
     }
 
+    @Override
     public void highlight(AEKey what) {
         if (isServerSide() && grid != null) {
             CraftingService service = (CraftingService) grid.getCraftingService();


### PR DESCRIPTION
This PR will allow you to highlight the locations where stacks are stored by pressing a hotkey over an entry in the terminal.
Makes the BlockHighlightPacket(s) usable for both this and the highlighting from the Crafting Status Screen by abstracting the logic away and making each of the respective menu's implement the new `IHighlightableMenu` interface.