### PR TITLE
Use cached inventory for terminals

### DIFF
--- a/src/main/java/appeng/menu/me/common/MEStorageMenu.java
+++ b/src/main/java/appeng/menu/me/common/MEStorageMenu.java
@@ -272,7 +272,22 @@ public class MEStorageMenu extends AEBaseMenu
             }
 
             var craftables = getCraftablesFromGrid();
-            var availableStacks = storage == null ? new KeyCounter() : storage.getAvailableStacks();
+
+            // Use the cached inventory for grid-connected terminals.
+            // Wireless terminals have networkNode == null but can still resolve a grid via IActionHost.
+            IGridNode gridNode = networkNode;
+            if (gridNode == null && host instanceof IActionHost actionHost) {
+                gridNode = actionHost.getActionableNode();
+            }
+
+            KeyCounter availableStacks;
+            if (gridNode != null && gridNode.getGrid() != null) {
+                KeyCounter cachedInventory = gridNode.getGrid().getStorageService().getCachedInventory();
+                availableStacks = new KeyCounter();
+                availableStacks.addAll(cachedInventory);
+            } else {
+                availableStacks = storage == null ? new KeyCounter() : storage.getAvailableStacks();
+            }
 
             // This is currently not supported/backed by any network service
             var requestables = new KeyCounter();


### PR DESCRIPTION
### What
broadcastChanges() calls storage.getAvailableStacks() every tick for every open terminal, which walks the entireNetworkStorage tree. StorageService already rebuilds and caches this exact data once per tick in onServerEndTick().

This PR makes terminals read from that cache instead when possible. This should save ~9% of AE2 execution time per tick on a typical server.

### Implementation details

For grid-connected terminals (blocks and wireless), it resolves the grid node, falling back to IActionHost.getActionableNode() for wireless terminals. It then reads getCachedInventory() from the grid node.

Portable cells and ME chests without grid access fall back to the original direct call.

The cached KeyCounter is copied via addAll() since broadcastChanges() mutates previousAvailableStacks for diff computation, and the cache is a direct reference to an object that gets reused.

The 9% number comes from a spark profile graph I'm looking at from a server with 6 players online, 5.25ms attributed to AE2, 0.45 for the getAvailableStacks calls inside the broadcast calls. Of course this is gonna depend on many things.